### PR TITLE
EXT:news v9 compatibility

### DIFF
--- a/Resources/Private/News/Partials/List/Pagination.html
+++ b/Resources/Private/News/Partials/List/Pagination.html
@@ -1,0 +1,43 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="http://xsd.helmut-hummel.de/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
+<f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
+    <f:variable name="prev"
+                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.previousPageNumber}, addQueryString:1, absolute: 1)}"/>
+</f:if>
+
+<f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
+    <f:variable name="next"
+                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.nextPageNumber}, addQueryString:1, absolute: 1)}"/>
+</f:if>
+
+<f:spaceless>
+    <f:format.raw>
+        <f:format.json value="{
+            first: '{f:uri.action(action:actionName, arguments:{currentPage: 1}, addQueryString:1, absolute: 1)}',
+            last: '{f:uri.action(action:actionName, arguments:{currentPage: pagination.lastPageNumber},addQueryString:1, absolute: 1)}',
+            prev: prev,
+            next: next,
+            pages: '{f:render(section: \'Pages\', arguments: \'{_all}\') -> headless:format.json.decode()}'
+        }"/>
+    </f:format.raw>
+</f:spaceless>
+
+<f:section name="Pages">
+    <f:spaceless>
+        <f:format.raw>
+            [
+            <f:for each="{pagination.allPageNumbers}" as="page" iteration="iterator">
+                <f:format.json value="{
+                page: '{page}',
+                link: '{f:uri.action(action:actionName, arguments:{currentPage: page},addQueryString:1, absolute: 1)}',
+                current: '{f:if(condition: \'{page} == {paginator.currentPageNumber}\', then: 1, else: 0)}'
+            }"/>
+                {f:if(condition: iterator.isLast, else: ',')}
+            </f:for>
+            ]
+        </f:format.raw>
+    </f:spaceless>
+</f:section>

--- a/Resources/Private/News/Templates/News/List.html
+++ b/Resources/Private/News/Templates/News/List.html
@@ -27,8 +27,8 @@
     </f:then>
     <f:else>
         <f:spaceless>
-            {"pagination": <n:widget.paginate objects="{news}" as="paginatedNews" configuration="{settings.list.paginate}" initial="{offset:settings.offset,limit:settings.limit,recordId:contentObjectData.uid}">
-                ,"list": [<f:for each="{paginatedNews}" as="newsItem" iteration="newsIterator">
+            {"pagination": <f:render partial="List/Pagination" arguments="{pagination: pagination.pagination, paginator: pagination.paginator}" />,
+                "list": [<f:for each="{pagination.paginator.paginatedItems}" as="newsItem" iteration="newsIterator">
             <f:if condition="{settings.excludeAlreadyDisplayedNews}">
                 <f:then>
                     <n:format.nothing>
@@ -48,7 +48,6 @@
                         action: 'list'
                     }"/>
                 </f:format.raw>
-            </n:widget.paginate>
             }
         </f:spaceless>
     </f:else>

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,11 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^9.5 || ^10.0"
+    "typo3/cms-core": "^10.0 || ^11.5"
   },
   "suggest": {
-    "friendsoftypo3/headless": "^2.0"
+    "friendsoftypo3/headless": "^2.0",
+    "georgringer/news": "^9.0"
   },
   "extra": {
      "typo3/cms": {


### PR DESCRIPTION
Version 9.0 of EXT:news removed the n:widget.paginate ViewHelper and replaced it with a Partial (List/Paginate.html)

The current EXT:headless_news version does not specify any compatible EXT:news version, but its templates still use the n:widget.paginate VH thus making it incompatible with EXT:news ^9.0

This PR removes the usage of the n:widget.paginate and replaces it with a a partial.

I also updated the composer.json suggest and require sections to reflect this change.